### PR TITLE
feat: add launcher app and setup scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Rsync to Raspberry Pi
+        uses: burnett01/rsync-deployments@5.1
+        with:
+          switches: -avzr --delete
+          path: ./
+          remote_path: ${{ secrets.PI_PATH }}
+          remote_host: ${{ secrets.PI_HOST }}
+          remote_user: ${{ secrets.PI_USER }}
+          remote_key: ${{ secrets.PI_SSH_KEY }}

--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ Turn your Raspberry Pi 5 into a Patreon TV box.
    ```bash
    sudo apt update
    sudo apt install -y git python3-tk chromium-browser
+   ```
+2. Set up autostart, VNC and git auto-pull:
+   ```bash
+   bash scripts/install_autostart.sh
+   bash scripts/setup_vnc.sh
+   bash scripts/enable_git_autopull.sh
+   ```

--- a/app/launcher.py
+++ b/app/launcher.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Tkinter launcher for Patreon TV box."""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import tkinter as tk
+from typing import Optional
+
+
+POLL_INTERVAL_MS = 1000  # How often to poll for IP address
+PATREON_URL = "https://www.patreon.com/home"
+
+
+def get_ip_address() -> Optional[str]:
+    """Return the LAN IP address or ``None`` if not available."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            # Connect to an external host; we don't actually send data
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except OSError:
+        return None
+
+
+def open_patreon(root: tk.Tk) -> None:
+    """Close the popup and launch Chromium."""
+    root.destroy()
+
+    kiosk = os.getenv("PATRON_FIRST_LOGIN", "0") != "1"
+    cmd = ["chromium-browser"]
+    if kiosk:
+        cmd.append("--kiosk")
+    cmd.append(PATREON_URL)
+    subprocess.Popen(cmd)
+
+
+def main() -> None:
+    root = tk.Tk()
+    root.title("Patreon Launcher")
+    root.attributes("-topmost", True)
+
+    ip_var = tk.StringVar(value="Detecting IP...")
+
+    label = tk.Label(root, textvariable=ip_var, font=("Arial", 14))
+    label.pack(padx=20, pady=10)
+
+    button = tk.Button(root, text="Open Patreon", state=tk.DISABLED,
+                       command=lambda: open_patreon(root))
+    button.pack(pady=10)
+
+    def poll_ip() -> None:
+        ip = get_ip_address()
+        if ip:
+            ip_var.set(f"IP: {ip}")
+            button.config(state=tk.NORMAL)
+        else:
+            ip_var.set("No network")
+            button.config(state=tk.DISABLED)
+        root.after(POLL_INTERVAL_MS, poll_ip)
+
+    poll_ip()
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/enable_git_autopull.sh
+++ b/scripts/enable_git_autopull.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install and enable systemd timer for automatic git pull
+
+REPO_DIR="${REPO_DIR:-/home/pi/patreon-tv-box}"
+SERVICE_DST="/etc/systemd/system/patreon-pull.service"
+TIMER_DST="/etc/systemd/system/patreon-pull.timer"
+
+sudo sed "s#/home/pi/patreon-tv-box#$REPO_DIR#g" systemd/patreon-pull.service | sudo tee "$SERVICE_DST" >/dev/null
+sudo cp systemd/patreon-pull.timer "$TIMER_DST"
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now patreon-pull.timer
+
+echo "Git auto-pull timer enabled"

--- a/scripts/install_autostart.sh
+++ b/scripts/install_autostart.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install autostart entry for launcher.py
+
+PI_HOME="${PI_HOME:-/home/pi}"
+AUTOSTART_DIR="$PI_HOME/.config/autostart"
+DESKTOP_FILE="$AUTOSTART_DIR/launcher.desktop"
+
+mkdir -p "$AUTOSTART_DIR"
+
+cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Patreon Launcher
+Exec=python3 $PI_HOME/patreon-tv-box/app/launcher.py
+X-GNOME-Autostart-enabled=true
+EOF
+
+echo "Created $DESKTOP_FILE"

--- a/scripts/setup_vnc.sh
+++ b/scripts/setup_vnc.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enable VNC and show connection info
+
+sudo raspi-config nonint do_vnc 0
+
+IP=$(hostname -I | awk '{print $1}')
+echo "VNC enabled. Connect using ${IP}:5901"

--- a/systemd/patreon-pull.service
+++ b/systemd/patreon-pull.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Pull latest code for Patreon TV box
+
+[Service]
+Type=oneshot
+User=pi
+WorkingDirectory=/home/pi/patreon-tv-box
+ExecStart=/usr/bin/git pull --ff-only

--- a/systemd/patreon-pull.timer
+++ b/systemd/patreon-pull.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run patreon-pull.service every minute
+
+[Timer]
+OnBootSec=30
+OnUnitActiveSec=60
+Unit=patreon-pull.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add Tkinter launcher that shows IP and opens Patreon in Chromium
- provide autostart, VNC setup, and git auto-pull scripts
- include systemd units and deploy workflow

## Testing
- `python -m py_compile app/launcher.py`
- `bash -n scripts/install_autostart.sh`
- `bash -n scripts/setup_vnc.sh`
- `bash -n scripts/enable_git_autopull.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b70069b9d883238424b3dcb38c98c6