### PR TITLE
docs: record Pi sync directory path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Turn a Raspberry Pi 5 into a “Patreon TV box”:
 - Chromium browser installed
 - Git installed
 - VNC server enabled (RealVNC preferred)
+- Repository synced at `/home/myk410/Pi-Patreon`
 
 ---
 


### PR DESCRIPTION
## Summary
- note Pi repository sync directory path in agents guide

## Testing
- `pytest` (no tests ran)

------
https://chatgpt.com/codex/tasks/task_e_68b7177513d8832387832cc37e31f576