### PR TITLE
fix: delay IP polling and handle missing ip

### DIFF
--- a/app/launcher.py
+++ b/app/launcher.py
@@ -27,8 +27,8 @@ def get_ip_address() -> Optional[str]:
         ).strip()
         if output:
             return output.split()[3].split("/")[0]
-    except (subprocess.CalledProcessError, IndexError):
-        pass
+    except (subprocess.CalledProcessError, OSError, IndexError):
+        print("ip command failed or wlan0 unavailable")
 
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
@@ -75,7 +75,7 @@ def main() -> None:
             button.config(state=tk.DISABLED)
         root.after(POLL_INTERVAL_MS, poll_ip)
 
-    poll_ip()
+    root.after(0, poll_ip)
     root.mainloop()
 
 


### PR DESCRIPTION
## Summary
- avoid aborting when `ip` command is missing by catching `OSError`
- ensure launcher window appears before IP lookup by polling after Tk start

## Testing
- `python -m py_compile app/launcher.py`
- `python app/launcher.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b71cfe60dc83239816b3c44bc52a0c