### PR TITLE
fix: prefer chromium binary

### DIFF
--- a/app/launcher.py
+++ b/app/launcher.py
@@ -44,7 +44,7 @@ def wait_for_network(timeout: int = NETWORK_TIMEOUT) -> None:
 
 def _find_chromium() -> str:
     """Return the first available Chromium executable."""
-    for name in ("chromium-browser", "chromium"):
+    for name in ("chromium", "chromium-browser"):
         path = shutil.which(name)
         if path:
             return path


### PR DESCRIPTION
## Summary
- prioritize `chromium` over `chromium-browser` so the launcher works on systems where only `/usr/bin/chromium` is functional

## Testing
- `python -m py_compile app/launcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7653390f883238a7074ba0a82b24e