### PR TITLE
feat: add fullscreen and window adjustment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Turn your Raspberry Pi 5 into a Patreon TV box.
 
 **Features:**
-- On login, Chromium automatically launches in fullscreen kiosk mode to Patreon.
+- On login, Chromium automatically launches to Patreon (fullscreen by default).
 - Supports Google Sign-In by keeping Chromium’s profile intact between sessions.
 - Remote control the Pi from iPhone or Mac via VNC.
 - Auto-sync with this GitHub repo using a systemd timer.
@@ -12,10 +12,11 @@ Turn your Raspberry Pi 5 into a Patreon TV box.
 
 ## How It Works
 1. Pi boots to Desktop.
-2. `launcher.py` waits for network connectivity and then launches Chromium in kiosk mode to `https://www.patreon.com/home`.
-   - Set `PATRON_FIRST_LOGIN=1` to temporarily disable kiosk mode for the first Google sign-in.
+2. `launcher.py` waits for network connectivity and then launches Chromium to `https://www.patreon.com/home`.
+   - `PATRON_FULLSCREEN` (default `1`) controls fullscreen; set to `0` for a normal window.
+   - `PATRON_KIOSK=1` launches in kiosk mode.
    - Adjust `NETWORK_TIMEOUT` (seconds) if your connection takes longer to come up.
-3. Videos play fullscreen on your TV via HDMI.
+3. Videos play on your TV via HDMI.
 4. If the Git auto-pull timer is enabled, changes to this repo will appear on the Pi within 60 seconds.
 
 ---

--- a/app/launcher.py
+++ b/app/launcher.py
@@ -42,6 +42,41 @@ def find_chromium() -> str:
             return path
     raise FileNotFoundError("Chromium executable not found (install 'chromium').")
 
+
+def nudge_window() -> None:
+    """Move Chromium to (0,0) and maximize if tools available."""
+    if not shutil.which("xdotool") or not shutil.which("wmctrl"):
+        logging.info("xdotool or wmctrl not available; skipping window adjustment")
+        return
+
+    end = time.time() + 5
+    window_id: str | None = None
+    while time.time() < end:
+        try:
+            result = subprocess.run(
+                ["xdotool", "search", "--onlyvisible", "--class", "Chromium"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            ids = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            if ids:
+                window_id = ids[0]
+                break
+        except Exception:
+            break
+        time.sleep(0.5)
+
+    if not window_id:
+        logging.info("Chromium window not found for adjustment")
+        return
+
+    subprocess.run(["wmctrl", "-ir", window_id, "-e", "0,0,0,-1,-1"], check=False)
+    subprocess.run(
+        ["wmctrl", "-ir", window_id, "-b", "add,maximized_horz,maximized_vert"],
+        check=False,
+    )
+
 def main() -> None:
     # Don’t try to open a GUI unless we’re in a desktop session
     if not os.environ.get("DISPLAY"):
@@ -52,6 +87,7 @@ def main() -> None:
 
     browser = find_chromium()
     kiosk = os.getenv("PATRON_KIOSK") == "1"
+    fullscreen = os.getenv("PATRON_FULLSCREEN", "1") == "1"
 
     cmd = [
         browser,
@@ -61,6 +97,11 @@ def main() -> None:
     ]
     if kiosk:
         cmd.append("--kiosk")
+    else:
+        if fullscreen:
+            cmd.append("--start-fullscreen")
+        else:
+            cmd.extend(["--start-maximized", "--window-position=0,0"])
     cmd.append(PATREON_URL)
 
     logging.info("Launching Chromium: %s", " ".join(cmd))
@@ -70,6 +111,9 @@ def main() -> None:
         logging.info("Chromium launched")
     except Exception:
         logging.exception("Failed to launch Chromium")
+
+    if not kiosk and not fullscreen:
+        nudge_window()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- default to fullscreen Chromium and expose `PATRON_FULLSCREEN` toggle
- allow kiosk mode via `PATRON_KIOSK` and post-launch window nudging
- document new env variables in README

## Testing
- `python -m py_compile app/launcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68b771d1b4b88323a0e83680eb785056