### PR TITLE
fix: default Patreon launcher to kiosk mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ Turn your Raspberry Pi 5 into a Patreon TV box.
 
 ## How It Works
 1. Pi boots to Desktop.
-2. `launcher.py` waits for network connectivity and then launches Chromium to `https://www.patreon.com/home`.
-   - `PATRON_FULLSCREEN` (default `1`) controls fullscreen; set to `0` for a normal window.
-   - `PATRON_KIOSK=1` launches in kiosk mode.
+2. `launcher.py` waits for network connectivity and then launches Chromium to `https://www.patreon.com/home` in fullscreen kiosk mode by default.
+   - Set `PATRON_FIRST_LOGIN=1` to disable kiosk for an initial manual sign-in.
    - Adjust `NETWORK_TIMEOUT` (seconds) if your connection takes longer to come up.
 3. Videos play on your TV via HDMI.
 4. If the Git auto-pull timer is enabled, changes to this repo will appear on the Pi within 60 seconds.

--- a/app/launcher.py
+++ b/app/launcher.py
@@ -51,7 +51,7 @@ def main() -> None:
     wait_for_network()
 
     browser = find_chromium()
-    kiosk = os.getenv("PATRON_KIOSK") == "1"
+    first_login = os.getenv("PATRON_FIRST_LOGIN") == "1"
 
     cmd = [
         browser,
@@ -59,8 +59,10 @@ def main() -> None:
         "--no-default-browser-check",
         "--password-store=basic",
     ]
-    if kiosk:
+
+    if not first_login:
         cmd.append("--kiosk")
+
     cmd.append(PATREON_URL)
 
     logging.info("Launching Chromium: %s", " ".join(cmd))


### PR DESCRIPTION
## Summary
- default Chromium launch to fullscreen kiosk mode
- document `PATRON_FIRST_LOGIN` for non-kiosk first run

## Testing
- `python -m py_compile app/launcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7756183b0832393d0491d1129ab0a