### PR TITLE
feat: arrange remote buttons in circular layout

### DIFF
--- a/remote-control/public/index.html
+++ b/remote-control/public/index.html
@@ -12,40 +12,51 @@
   />
 </head>
 <body class="bg-light">
-  <div class="container py-5">
-    <div class="row justify-content-center mb-3">
-      <div class="col-4 text-center">
-        <button class="btn btn-secondary btn-lg w-100" onclick="send('rewind')">
-          &#9194;
-        </button>
-      </div>
-      <div class="col-4 text-center">
-        <button class="btn btn-primary btn-lg w-100" onclick="send('play')">
-          &#9658;
-        </button>
-      </div>
-      <div class="col-4 text-center">
-        <button class="btn btn-secondary btn-lg w-100" onclick="send('fast-forward')">
-          &#9193;
-        </button>
-      </div>
+  <div class="container py-5 d-flex flex-column align-items-center">
+    <div
+      class="position-relative rounded-circle bg-white border mb-4"
+      style="width: 200px; height: 200px;"
+    >
+      <button
+        class="btn btn-secondary position-absolute top-50 start-0 translate-middle-y"
+        style="width: 80px; height: 80px;"
+        onclick="send('rewind')"
+      >
+        &#9194;
+      </button>
+      <button
+        class="btn btn-primary position-absolute top-0 start-50 translate-middle"
+        style="width: 80px; height: 80px;"
+        onclick="send('play')"
+      >
+        &#9658;
+      </button>
+      <button
+        class="btn btn-secondary position-absolute top-50 end-0 translate-middle-y"
+        style="width: 80px; height: 80px;"
+        onclick="send('fast-forward')"
+      >
+        &#9193;
+      </button>
+      <button
+        class="btn btn-secondary position-absolute bottom-0 start-50 translate-middle"
+        style="width: 80px; height: 80px;"
+        onclick="send('pause')"
+      >
+        &#10074;&#10074;
+      </button>
     </div>
 
-    <div class="row justify-content-center mb-3">
-      <div class="col-4 text-center">
-        <button class="btn btn-secondary btn-lg w-100" onclick="send('pause')">
-          &#10074;&#10074;
-        </button>
-      </div>
-    </div>
-
-    <div class="row justify-content-center">
-      <div class="col-6 text-center mb-2">
-        <button class="btn btn-secondary w-100" onclick="send('skip-back')">-10s</button>
-      </div>
-      <div class="col-6 text-center mb-2">
-        <button class="btn btn-secondary w-100" onclick="send('skip-forward')">+10s</button>
-      </div>
+    <div class="d-flex justify-content-center">
+      <button
+        class="btn btn-secondary me-2"
+        onclick="send('skip-back')"
+      >
+        -10s
+      </button>
+      <button class="btn btn-secondary" onclick="send('skip-forward')">
+        +10s
+      </button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Arrange rewind/play/fast-forward/pause in a circular layout with absolute positioning for a remote-like control.
- Place skip-back and skip-forward buttons centered below the control.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba5bbf151c8323ba37746ab8bbf493