### PR TITLE
fix: close container div in remote control page

### DIFF
--- a/remote-control/public/index.html
+++ b/remote-control/public/index.html
@@ -83,9 +83,10 @@
           <div class="col-4"></div>
         </div>
       </div>
+    </div>
   </div>
 
-  <script>
+    <script>
     function send(cmd) {
       fetch(`/${cmd}`, { method: 'POST' })
         .catch(err => console.error('Request failed:', err));


### PR DESCRIPTION
## Summary
- close missing container div in remote control HTML before script block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba60a24ccc832383597a01b0ac15dc