### PR TITLE
fix: center remote layout and labels

### DIFF
--- a/remote-control/public/index.html
+++ b/remote-control/public/index.html
@@ -11,17 +11,27 @@
     crossorigin="anonymous"
   />
   <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      background-color: #000;
+    }
     .remote-grid {
       display: grid;
       grid-template-columns: repeat(8, 1fr);
       gap: 0.5rem;
       width: 100%;
       max-width: 80vmin;
+      margin: auto;
     }
     .remote-grid button {
       width: 100%;
       aspect-ratio: 1;
       font-size: 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
     }
     .play { grid-column: 4 / span 2; grid-row: 1; }
     .rewind { grid-column: 2 / span 2; grid-row: 2; }
@@ -31,8 +41,8 @@
     .skip-forward { grid-column: 5 / span 2; grid-row: 4; }
   </style>
 </head>
-<body class="bg-black text-white">
-  <div class="container-fluid px-0 d-flex flex-column justify-content-center align-items-center vh-100">
+<body class="text-white">
+  <div class="container-fluid p-0 d-flex flex-column justify-content-center align-items-center min-vh-100">
     <div class="remote-grid">
       <button class="btn btn-primary play" onclick="send('play')">
         &#9658;


### PR DESCRIPTION
## Summary
- ensure remote page background is consistently black
- center remote control grid and button labels across screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba65b10b8c8323a8c6568a2d89b45e