### PR TITLE
fix: improve remote control keystroke handling

### DIFF
--- a/remote-control/README.md
+++ b/remote-control/README.md
@@ -12,6 +12,10 @@ npm start
 
 Open a browser to `http://<host>:3000` to use the remote control interface.
 
+The server targets the default X display (`:0`) and uses `/home/pi/.Xauthority`
+if those environment variables are not provided. Override `DISPLAY` and
+`XAUTHORITY` before starting the server if your setup differs.
+
 Requires [`xdotool`](https://github.com/jordansissel/xdotool) to be installed:
 
 ```bash

--- a/remote-control/server.js
+++ b/remote-control/server.js
@@ -10,29 +10,64 @@ const HOST = process.env.HOST || "0.0.0.0"; // listen on all interfaces
 // Serve the static control page from the public directory
 app.use(express.static(path.join(__dirname, "public")));
 
+// Default environment for xdotool when launched outside a desktop session.
+// Using DISPLAY=:0 targets the primary X server on Raspberry Pi OS.
+const X_ENV = {
+  DISPLAY: process.env.DISPLAY || ":0",
+  XAUTHORITY: process.env.XAUTHORITY || "/home/pi/.Xauthority",
+};
+
+// Locate the first visible Chromium window. Chromium on Raspberry Pi may
+// expose different WM_CLASS values (e.g. "chromium", "Chromium", or
+// "chromium-browser"). We try a few known variants and use the first result.
+function findChromiumWindow(cb) {
+  const classes = ["chromium", "Chromium", "chromium-browser"];
+  const tryNext = (i) => {
+    if (i >= classes.length) return cb(new Error("Chromium window not found"));
+    const cmd = `xdotool search --onlyvisible --class ${classes[i]} | head -n 1`;
+    exec(cmd, { env: { ...process.env, ...X_ENV } }, (err, stdout) => {
+      const id = stdout && stdout.trim();
+      if (!err && id) {
+        cb(null, id);
+      } else {
+        tryNext(i + 1);
+      }
+    });
+  };
+  tryNext(0);
+}
+
 // Helper to send keystrokes to Chromium using xdotool
 function key(key, res) {
-  const cmd = `xdotool key --window $(xdotool search --onlyvisible --class chromium | head -n 1) ${key}`;
-  exec(cmd, (err, stdout, stderr) => {
-    if (err) {
-      console.error("xdotool error:", err.message || err, stderr);
-      return res.status(500).json({
-        ok: false,
-        error: err.message || String(err)
-      });
+  findChromiumWindow((winErr, id) => {
+    if (winErr) {
+      console.error("xdotool search error:", winErr.message);
+      return res.status(500).json({ ok: false, error: winErr.message });
     }
-    res.json({ ok: true });
+    const cmd = `xdotool key --window ${id} ${key}`;
+    exec(cmd, { env: { ...process.env, ...X_ENV } }, (err, stdout, stderr) => {
+      if (err) {
+        console.error("xdotool error:", err.message || err, stderr);
+        return res.status(500).json({
+          ok: false,
+          error: err.message || String(err),
+        });
+      }
+      res.json({ ok: true });
+    });
   });
 }
 
 // Control endpoints
-app.post("/play",         (_, res) => key("space", res));
-app.post("/pause",        (_, res) => key("space", res));
-app.post("/play-pause",   (_, res) => key("space", res));
-app.post("/rewind",       (_, res) => key("Left", res));
-app.post("/fast-forward", (_, res) => key("Right", res));
-app.post("/skip-back",    (_, res) => key("Shift+Left", res));
-app.post("/skip-forward", (_, res) => key("Shift+Right", res));
+// Control endpoints map simple button presses to YouTube-style shortcuts.
+// Many embedded Patreon videos use the same key bindings.
+app.post("/play",         (_, res) => key("k", res));
+app.post("/pause",        (_, res) => key("k", res));
+app.post("/play-pause",   (_, res) => key("k", res));
+app.post("/rewind",       (_, res) => key("Left", res)); // 5 seconds back
+app.post("/fast-forward", (_, res) => key("Right", res)); // 5 seconds forward
+app.post("/skip-back",    (_, res) => key("j", res)); // 10 seconds back
+app.post("/skip-forward", (_, res) => key("l", res)); // 10 seconds forward
 app.post("/toggle-fullscreen", (_, res) => key("f", res));
 
 // Start server


### PR DESCRIPTION
## Summary
- make remote server search for Chromium window reliably and set default X env
- align remote control keys with YouTube-style shortcuts for Patreon videos

## Testing
- `npm test --prefix remote-control`


------
https://chatgpt.com/codex/tasks/task_e_68ba663cc23c832387d7ee22d256281b